### PR TITLE
feat(Ruby) add support for ruby 3

### DIFF
--- a/lib/runt.rb
+++ b/lib/runt.rb
@@ -190,13 +190,13 @@ class Time
 
   attr_accessor :date_precision
   alias_method :old_initialize, :initialize
-  def initialize(*args)
+  def initialize(*args, **kwargs)
     if(args[0].instance_of?(Runt::DPrecision::Precision))
       @precision=args.shift
     else
       @precision=Runt::DPrecision::SEC
     end
-    old_initialize(*args)
+    old_initialize(*args, **kwargs)
   end
 
 #  alias :old_to_yaml :to_yaml


### PR DESCRIPTION
### What
Adds support for ruby 3. fixes git blame in vs code.

### Why
Calendar uses this gem, and adding ruby 3 support to this gem is a prerequisite to getting Calendar on ruby 3.

### How
0) tried to update ruby in calendar and saw a runt error.
1) used rbenv to set the local ruby version to 3.1 (it defaulted to the system version of 2.6 )
2) ran unit tests, saw the same error from step 0.
3) added explicit kwargs
4) verified that tests passed!
5) profit.

### Links
https://app.asana.com/0/1202945566844673/1203767530593572