### PR TITLE
chore(CODEOWNERS): add calendar as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/calendar


### PR DESCRIPTION
Looking through the commits it seems this was forked by Calendar. If someone else should own it, let me know! 🙏